### PR TITLE
Add build badge to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,29 @@
-# Whalelint
+# Whalelint  <img align="right" src="https://github.com/cremindes/whalelint/workflows/build/badge.svg" />
 
 Dockerfile linter written in Go
 
-Disclaimer: this is a pet-project while I'm learning Golang.
+*Disclaimer: this is a pet-project while I'm learning Golang.*
 
 ## Feature list
 
-- extendable ruleset
-- rule escaping per line
-- config file
-- output coloring
-- output as json
-- cli
+- [x] extendable ruleset
+- [ ] cli
+- [X] output as json
+- [ ] rule escaping per line
+- [ ] output coloring
+- [ ] config file
 
 ## Rules
 
+Each Dockerfile AST element has a corresponding set of rules. 
+
 TODO
+
+## Sample output
+
+TODO
+
+## Plugins
+
+- JetBrains
+- VSCode


### PR DESCRIPTION
Standard GitHub build badge currently looking at build + test.