### PR TITLE
bugfix: empty BashCommand due to unhandled switch branch.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cremindes/whalelint
 go 1.15
 
 require (
+	github.com/docker/docker v20.10.0-beta1.0.20201110211921-af34b94a78a1+incompatible
 	github.com/google/go-cmp v0.5.4 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/moby/buildkit v0.8.1

--- a/parser/bash.go
+++ b/parser/bash.go
@@ -5,6 +5,7 @@ package parser
 import (
 	"strings"
 
+	"github.com/docker/docker/api/types/strslice"
 	"github.com/google/shlex"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	log "github.com/sirupsen/logrus"
@@ -107,6 +108,10 @@ func ParseBashCommandChain(command interface{}) BashCommandChain {
 		lex, err = shlex.Split(strings.Join(c.ShellDependantCmdLine.CmdLine, ""))
 	case []string:
 		lex, err = shlex.Split(strings.Join(c, " "))
+	case strslice.StrSlice:
+		lex, err = shlex.Split(strings.Join(c, " "))
+	default:
+		err = Utils.ErrUnSupportedType
 	}
 
 	if err != nil || len(lex) == 0 {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 )
 
+/* Errors */
+var ErrUnSupportedType = errors.New("unsupported type")
+
 /* String helper functions. */
 
 // EqualsEither returns true, if str string is a match to any element of the targetList, false otherwise.


### PR DESCRIPTION
Passing unhandled ```switch``` branch to ```parser::ParseBashCommandChain```
- ```strslice.StrSlice``` in this case - wasn't handled properly, moreover
poorly, as the ```default``` branch was missing.

New error type was added to package ```utils```