### PR TITLE
Safe Dockerfile parse wrapper around buildkit.

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,25 +5,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 
-	"github.com/moby/buildkit/frontend/dockerfile/instructions"
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	log "github.com/sirupsen/logrus"
 	"robpike.io/filter"
 
-	Linter  "github.com/cremindes/whalelint/linter"
+	Linter "github.com/cremindes/whalelint/linter"
 	RuleSet "github.com/cremindes/whalelint/linter/ruleset"
+	Utils "github.com/cremindes/whalelint/utils"
 )
 
 func main() {
+	log.SetLevel(log.DebugLevel)
 	log.Debug("We have", RuleSet.Get().Count(), "ruleset.")
 
 	/* CLI - TODO */
 	filePath := os.Args[1]
 
 	/* Parse Dockerfile */
-	stageList, metaArgs := getDockerfileAst(filePath)
+	stageList, metaArgs := Utils.GetDockerfileAst(filePath)
 	if metaArgs != nil {
 		log.Debug("metaArgs |", metaArgs)
 	}
@@ -37,27 +36,6 @@ func main() {
 
 	/* Print result | TODO: cli dependent output */
 	printResultAsJSON(violations)
-}
-
-func getDockerfileAst(filePathString string) (stages []instructions.Stage, metaArgs []instructions.ArgCommand) {
-	filePath := filepath.Clean(filePathString)
-
-	fileHandle, err := os.Open(filePath)
-	if err != nil {
-		log.Error("Cannot open Dockerfile \"", filePath, "\".", err)
-	}
-
-	dockerfile, err := parser.Parse(fileHandle)
-	if err != nil {
-		log.Error("Cannot parse Dockerfile \"", filePath, "\"", err)
-	}
-
-	stageList, metaArgs, err := instructions.Parse(dockerfile.AST)
-	if err != nil {
-		log.Error("Cannot create Dockerfile AST from \"", filePath, "\".", err)
-	}
-
-	return stageList, metaArgs
 }
 
 func printResultAsJSON(violations interface{}) {


### PR DESCRIPTION
`builkit` might panic upon parsing the `instructions` representation out of the `AST`. This PR introduces a safe fallback mechanism, that finds the offending line in a try-catch manner and removes that node from the AST tree and then tries again till it succeeds or there is no more line offending line to remove.