### PR TITLE
Add CLI.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	log "github.com/sirupsen/logrus"
+	"robpike.io/filter"
+
+	Linter "github.com/cremindes/whalelint/linter"
+	RuleSet "github.com/cremindes/whalelint/linter/ruleset"
+	Report "github.com/cremindes/whalelint/report"
+	Utils "github.com/cremindes/whalelint/utils"
+)
+
+/*
+CLI plan so far:
+
+Commands:
+  help [automatic]
+  lsp
+	--port
+    -c, --config
+  lint [default]
+    - | --output [textsummary, json]
+    --short-summary? [mutually exclusive with output?]
+    --return-value [program,lint]
+    file list
+	-c, --config
+  version
+*/
+
+type WhaleLintCLI struct {
+	Lint    LintCommand    `kong:"cmd,help='run linter.'"`
+	Version VersionCommand `kong:"cmd,help='show version.'"`
+
+	Config  string         `kong:"help='config file path'"` // nolint:gofmt,gofumpt,goimports
+}
+
+func (*WhaleLintCLI) Options() []kong.Option {
+	return []kong.Option{
+		kong.Name("whalelint"),
+		kong.Description("WhaleLint is a Dockerfile linter. It can function as\n" +
+			"  - CLI linter as default\n" +
+			"  - Pre-commit hook with option --return-value=\"errnum\"\n" +
+			"  - CI linter with options like --format=json and/or --return-value=\"errnum\"\n" +
+			"  - Language server for plugins\n" +
+			" (- GitHub Action - in the roadmap)" + "\n" +
+			"More documentation at https://github.com/CreMindES/whalelint"),
+		kong.UsageOnError(),
+		kong.ConfigureHelp(kong.HelpOptions{ // nolint:exhaustivestruct
+			Compact: true,
+		}),
+	}
+}
+
+type LintCommand struct { // nolint:maligned
+	Format       string   `kong:"help='TODO',default:'summary',enum:'json,summary'"`
+	NoColor      bool     `kong:"help='No color output'"`
+	Paths        []string `kong:"arg,required,help:'Paths to remove.',type:'path'"`
+	ReturnValue  string   `kong:"help='Return value TODO'"`
+	ShortSummary bool     `kong:"help='Print only a short summary.'"`
+}
+
+func (lintCommand *LintCommand) Run() error {
+	log.Println("Running linter... TODO", lintCommand)
+
+	if len(lintCommand.Paths) > 1 {
+		log.Warning("Although it's planned, for now only one Dockerfile can be validated at a time.")
+	}
+
+	filePath := lintCommand.Paths[0]
+
+	// TODO: move to parser
+	/* Parse Dockerfile */
+	stageList, metaArgs, err := Utils.GetDockerfileAst(filePath)
+	if err != nil {
+		return fmt.Errorf("linter | %w", err)
+	}
+
+	if metaArgs != nil {
+		log.Debug("metaArgs |", metaArgs)
+	}
+
+	// Run Linter
+	linter := Linter.Linter{}
+	ruleValidationResultArray := linter.Run(stageList)
+	violations := filter.Choose(ruleValidationResultArray,
+		func(x RuleSet.RuleValidationResult) bool {
+			return x.IsViolated()
+		},
+	)
+
+	/* Print result | TODO: cli dependent output */
+	Report.PrintResultAsJSON(violations)
+
+	return nil
+}
+
+type VersionCommand struct{}
+
+func (versionCommand *VersionCommand) Run(k *kong.Context) error {
+	version := "v0.0.1"
+	k.Printf("%s", version)
+
+	return nil
+}
+
+func (t WhaleLintCLI) ApplyDefaultCommand(err error, args *[]string) {
+	var parseError *kong.ParseError
+	if errors.As(err, &parseError) {
+		if !strings.HasPrefix(err.Error(), "unknown flag") {
+			// insert the default command in case there is only one argument
+			// supporting case of ./whalelint [Dockerfile path] -> ./whalelint lint [Dockerfile path]
+			*args = append([]string{"lint"}, *args...)
+		}
+	}
+}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,0 +1,250 @@
+package cli_test
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+	log "github.com/sirupsen/logrus"
+	"gotest.tools/assert"
+
+	"github.com/cremindes/whalelint/cli"
+)
+
+type StdBuffer struct {
+	stdOut *bytes.Buffer
+	stdErr *bytes.Buffer
+}
+
+func generateStdBuffer() StdBuffer {
+	return StdBuffer{
+		stdOut: &bytes.Buffer{},
+		stdErr: &bytes.Buffer{},
+	}
+}
+
+func generateCLI(args []string) (*kong.Context, StdBuffer, error) {
+	cli := cli.WhaleLintCLI{}
+	parser := kong.Must(&cli, cli.Options()...)
+	stdBuffer := generateStdBuffer()
+	parser.Stdout, parser.Stderr = stdBuffer.stdOut, stdBuffer.stdErr
+
+	ctx, err := parser.Parse(args)
+
+	return ctx, stdBuffer, err // nolint:wrapcheck
+}
+
+func generateKongParseErrorUnknownFlag(t *testing.T) *kong.ParseError {
+	t.Helper()
+
+	args := []string{"--nonExistingFlag"}
+	_, _, err := generateCLI(args)
+
+	var kongParseError *kong.ParseError
+	if !errors.As(err, &kongParseError) {
+		t.FailNow()
+	}
+
+	return kongParseError
+}
+
+func TestVersionCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	args := []string{"version"}
+
+	ctx, stdBuffer, err := generateCLI(args)
+	assert.NilError(t, err)
+
+	err = ctx.Run()
+	assert.NilError(t, err)
+
+	assert.Equal(t, "whalelint: v0.0.1\n", stdBuffer.stdOut.String())
+	assert.Equal(t, "", stdBuffer.stdErr.String())
+}
+
+func TestCliType_ApplyDefaultCommand(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Name     string
+		Args     []string
+		Err      *kong.ParseError
+		Expected []string
+	}{
+		{
+			Name:     "Call default lint with path",
+			Args:     []string{"pathToDockerfile"},
+			Err:      generateKongParseErrorUnknownFlag(t),
+			Expected: []string{"lint", "pathToDockerfile"},
+		},
+		{
+			Name:     "Call explicit lint with path",
+			Args:     []string{"lint", "pathToDockerfile"},
+			Err:      nil,
+			Expected: []string{"lint", "pathToDockerfile"},
+		},
+		{
+			Name:     "Call version",
+			Args:     []string{"version"},
+			Err:      nil,
+			Expected: []string{"version"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+
+			// prepare
+			cli := cli.WhaleLintCLI{}
+			parser := kong.Must(&cli, cli.Options()...)
+			_, err := parser.Parse(testCase.Args)
+			args := testCase.Args
+
+			// test target
+			cli.ApplyDefaultCommand(err, &args)
+
+			// check
+			assert.DeepEqual(t, testCase.Expected, args)
+		})
+	}
+}
+
+// nolint:funlen,paralleltest
+func TestLintCommand_Run(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		TmpFileContent []string
+		Expected       error
+		ExpectedErrStr string
+		ExpectedStdout string
+	}{
+		{
+			Name:           "Call lint with path of simple Dockerfile.",
+			TmpFileContent: []string{"FROM golang:1.16"},
+			Expected:       nil,
+			ExpectedErrStr: "",
+			ExpectedStdout: "",
+		},
+		{
+			Name:           "Call lint with path of non-existing file",
+			TmpFileContent: []string{""},
+			Expected:       syscall.ENOENT,
+			ExpectedErrStr: "no such file",
+			ExpectedStdout: "",
+		},
+		{
+			Name:           "Call lint with path empty file",
+			TmpFileContent: []string{" "},
+			Expected:       &parser.ErrorLocation{},
+			ExpectedErrStr: "file with no instructions",
+			ExpectedStdout: "",
+		},
+		{
+			Name:           "Call lint with path of simple Dockerfile with args.",
+			TmpFileContent: []string{"ARG from=\"golang 1.16\"\nFROM ${from}"},
+			Expected:       nil,
+			ExpectedErrStr: "",
+			ExpectedStdout: "",
+		},
+		{
+			Name:           "Call lint with 2 paths of simple Dockerfiles",
+			TmpFileContent: []string{"FROM golang:1.16", "FROM golang:1.16"},
+			Expected:       nil,
+			ExpectedErrStr: "",
+			ExpectedStdout: "Although it's planned, for now only one Dockerfile can be validated at a time.",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.Name, func(t *testing.T) {
+			// t.Parallel() - Linter is not thread safe!
+
+			stdOut := &strings.Builder{}
+			log.SetOutput(stdOut)
+
+			tmpFileSlice := make([]*os.File, len(testCase.TmpFileContent))
+			os.Args = make([]string, 1, len(tmpFileSlice))
+			os.Args[0] = "lint"
+
+			for i, fileContent := range testCase.TmpFileContent {
+				if len(fileContent) > 0 {
+					tmpFileSlice[i], _ = ioutil.TempFile("", "mock-dockerfile.*")
+
+					_, errTmpFile := tmpFileSlice[i].WriteString(fileContent)
+					assert.NilError(t, errTmpFile)
+					errTmpFile = tmpFileSlice[i].Sync()
+					assert.NilError(t, errTmpFile)
+
+					os.Args = append(os.Args, tmpFileSlice[i].Name())
+				}
+			}
+
+			if len(os.Args) == 1 {
+				os.Args = append(os.Args, "bogusPath")
+			}
+
+			ctx, _, err := generateCLI(os.Args)
+			assert.NilError(t, err)
+
+			err = ctx.Run()
+
+			isSameErr := CheckForErrorRecursively(t, err, testCase.Expected)
+			assert.Equal(t, true, isSameErr)
+			if testCase.Expected != nil {
+				assert.ErrorContains(t, err, testCase.ExpectedErrStr)
+			}
+			println(stdOut.String())
+			if len(testCase.ExpectedStdout) > 0 {
+				assert.Equal(t, true, strings.Contains(stdOut.String(), testCase.ExpectedStdout))
+			}
+
+			for _, tmpFile := range tmpFileSlice {
+				if tmpFile != nil {
+					os.Remove(tmpFile.Name())
+				}
+			}
+		})
+	}
+}
+
+func CheckForErrorRecursively(t *testing.T, err error, target error) bool {
+	t.Helper()
+
+	// first check for unwrapped errors, especially where both are nil
+	if err == nil && target == nil {
+		return true
+	}
+
+	if errors.Is(err, target) {
+		return true
+	}
+
+	unWrappedErr := err
+	targetType := reflect.TypeOf(target)
+
+	for {
+		e := errors.Unwrap(unWrappedErr)
+		if e != nil {
+			unWrappedErr = e
+
+			if reflect.TypeOf(e) == targetType {
+				return true
+			}
+		} else {
+			return false
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
+	github.com/alecthomas/kong v0.2.15
 	github.com/docker/docker v20.10.0-beta1.0.20201110211921-af34b94a78a1+incompatible
 	github.com/google/go-cmp v0.5.4 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -16,5 +17,6 @@ require (
 	github.com/zoumo/goset v0.2.0
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gotest.tools v2.2.0+incompatible
 	robpike.io/filter v0.0.0-20150108201509-2984852a2183
 )

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -7,9 +7,15 @@ import (
 	RuleSet "github.com/cremindes/whalelint/linter/ruleset"
 )
 
+var MainLinter Linter // nolint:gochecknoglobals
+
+// Linter
+// TODO: add config Config.
+type Linter struct{}
+
 // nolint:nestif, funlen, gocognit
 /* Validate each Dockerfile AST entry against rules in ruleset package. */
-func Run(stageList []instructions.Stage) []RuleSet.RuleValidationResult {
+func (l *Linter) Run(stageList []instructions.Stage) []RuleSet.RuleValidationResult {
 	var ruleValidationResultArray []RuleSet.RuleValidationResult // nolint:prealloc
 
 	// Call Dockerfile AST level validators

--- a/linter/ruleset/rule.go
+++ b/linter/ruleset/rule.go
@@ -38,7 +38,7 @@ func (severity Severity) String() string {
 	case ValWarning:
 		return "Warning"
 	case ValUnknown:
-		return "Unknown"
+		return "Unknown" // nolint:goconst
 	default:
 		return "Unknown"
 	}

--- a/linter/ruleset/validationresult.go
+++ b/linter/ruleset/validationresult.go
@@ -114,7 +114,7 @@ func (ruleValidationResult *RuleValidationResult) RuleID() string {
 
 func (ruleValidationResult *RuleValidationResult) Message() string {
 	if len(ruleValidationResult.message) == 0 {
-		return ruleValidationResult.rule.Description()
+		return ruleValidationResult.rule.Definition()
 	}
 
 	return ruleValidationResult.message

--- a/linter/ruleset/validationresult_test.go
+++ b/linter/ruleset/validationresult_test.go
@@ -12,7 +12,7 @@ import (
 
 func newMockRule() *RuleSet.Rule {
 	mockFunc := func(command *instructions.Command) /* RuleSet.RuleValidationResult */ {}
-	mockRule := RuleSet.NewRule("FakeID", "Fake definition", "MockDesc", RuleSet.ValUnknown, mockFunc)
+	mockRule := RuleSet.NewRule("FakeID", "MockDef", "MockDesc", RuleSet.ValUnknown, mockFunc)
 
 	return mockRule
 }
@@ -148,19 +148,21 @@ func TestRuleValidationResult_SetViolated(t *testing.T) { // nolint:funlen
 	//
 	// logger.Println("test")
 
-// 	_, hook := test.NewNullLogger()
-//
-// 	valResult := RuleSet.NewRuleValidationResult(MockRule, false, "", mockLoc)
-// 	valResult.SetViolated(true, true, true)
-// // 	assert.Contains(t, "Invalid params to RuleValidationResult::SetViolated" ,buffer.String())
-// 	assert.Equal(t, Log.ErrorLevel, hook.LastEntry().Level)
+	// 	_, hook := test.NewNullLogger()
+	//
+	// 	valResult := RuleSet.NewRuleValidationResult(MockRule, false, "", mockLoc)
+	// 	valResult.SetViolated(true, true, true)
+	// // 	assert.Contains(t, "Invalid params to RuleValidationResult::SetViolated" ,buffer.String())
+	// 	assert.Equal(t, Log.ErrorLevel, hook.LastEntry().Level)
+
+	return // nolint:gosimple
 }
 
 func TestRuleValidationResult_SetLocation(t *testing.T) {
 	t.Parallel()
 
 	mockRule := newMockRule()
-	mockLoc  := newMockLocation()
+	mockLoc := newMockLocation()
 	ruleValidationResult := RuleSet.NewRuleValidationResult(mockRule, false, "", mockLoc)
 
 	startLine, startChar, endLine, endChar :=
@@ -173,7 +175,7 @@ func TestRuleValidationResult_SetLocation(t *testing.T) {
 
 	assert.Equal(t, startLine, ruleValidationResult.Location().Start().LineNumber())
 	assert.Equal(t, startChar, ruleValidationResult.Location().Start().CharNumber())
-	assert.Equal(t,   endLine, ruleValidationResult.Location().End().LineNumber())
+	assert.Equal(t,   endLine, ruleValidationResult.Location().End().LineNumber()) // nolint:gofmt,gofumpt,goimports
 	assert.Equal(t,   endChar, ruleValidationResult.Location().End().CharNumber())
 }
 
@@ -192,6 +194,7 @@ func TestRuleValidationResult_SetLocationRangeFrom(t *testing.T) {
 	assert.Equal(t, mockLoc2, *ruleValidationResult.Location())
 }
 
+// nolint:gofmt,gofumpt,goimports
 func TestRuleValidationResult_Message(t *testing.T) {
 	t.Parallel()
 
@@ -201,6 +204,6 @@ func TestRuleValidationResult_Message(t *testing.T) {
 	ruleValidationResultWithoutMessage := RuleSet.NewRuleValidationResult(mockRule, false, "", mockLoc)
 	ruleValidationResultWithMessage    := RuleSet.NewRuleValidationResult(mockRule, false, mockMessage, mockLoc)
 
-	assert.Equal(t, ruleValidationResultWithoutMessage.Description(), ruleValidationResultWithoutMessage.Message())
+	assert.Equal(t, mockRule.Definition(), ruleValidationResultWithoutMessage.Message())
 	assert.Equal(t, mockMessage, ruleValidationResultWithMessage.Message())
 }

--- a/report/report.go
+++ b/report/report.go
@@ -1,0 +1,17 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func PrintResultAsJSON(violations interface{}) {
+	resultJSON, err := json.Marshal(violations)
+	if err != nil {
+		log.Error(err)
+	}
+
+	fmt.Println(string(resultJSON)) // nolint:forbidigo
+}


### PR DESCRIPTION
- CLI lib is kong.
- Supported commands: version, lint and config placeholder.
- Moved basic CLI logic and corresponding parts from main.go to cli/cli.
- Moved JSON output from main.go to report/report.go.
- Linter instance instead of simple functions
- Golangci-lint finding fixes

```
CLI plan so far:

Commands:
  help [automatic]
  lsp
	--port
    -c, --config
  lint [default]
    - | --output [textsummary, json]
    --short-summary? [mutually exclusive with output?]
    --return-value [program,lint]
    file list
	-c, --config
  version
```