### PR TITLE
Bug/issue 34 false positive on cpy006 for basic copy command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -140,7 +140,7 @@ func (lspCommand *LspCommand) Run() error {
 type VersionCommand struct{}
 
 func (versionCommand *VersionCommand) Run(k *kong.Context) error {
-	version := "v0.0.1"
+	version := "v0.0.2"
 	k.Printf("%s", version)
 
 	return nil

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -67,7 +67,7 @@ func TestVersionCommand_Run(t *testing.T) {
 	err = ctx.Run()
 	assert.NilError(t, err)
 
-	assert.Equal(t, "whalelint: v0.0.1\n", stdBuffer.stdOut.String())
+	assert.Equal(t, "whalelint: v0.0.2\n", stdBuffer.stdOut.String())
 	assert.Equal(t, "", stdBuffer.stdErr.String())
 }
 

--- a/linter/ruleset/cpy006.go
+++ b/linter/ruleset/cpy006.go
@@ -14,8 +14,8 @@ func ValidateCpy006(stage instructions.Stage) RuleValidationResult {
 
 	for _, command := range stage.Commands {
 		if copyCommand, ok := command.(*instructions.CopyCommand); ok {
-			if copyCommand.From == stage.Name || copyCommand.From == stage.BaseName ||
-				Utils.MatchDockerImageNames(copyCommand.From, stage.BaseName) {
+			if len(copyCommand.From) > 0 && (copyCommand.From == stage.Name || copyCommand.From == stage.BaseName ||
+				Utils.MatchDockerImageNames(copyCommand.From, stage.BaseName)) {
 				result.SetViolated()
 				result.LocationRange = ParseLocationFromRawParser(copyCommand.From, copyCommand.Location())
 			}

--- a/linter/ruleset/cpy006_test.go
+++ b/linter/ruleset/cpy006_test.go
@@ -90,6 +90,15 @@ func TestValidateCpy006(t *testing.T) {
                           FROM {{ .StageBase }}
                           COPY --from {{ .CopyFrom }}`,
 		},
+		{
+			IsViolation: false,
+			ExampleName: "Simple COPY src dst",
+			StageName: "", StageBase: "foo:latest", CopyFrom: "",
+			DocsContext: `FROM golang:1.15 as {{ .StageName }}
+                          RUN go build app
+                          FROM {{ .StageBase }}
+                          COPY src dst`,
+		},
 	}
 
 	RuleSet.RegisterTestCaseDocs("CPY006", testCases)

--- a/plugins/vscode/package-lock.json
+++ b/plugins/vscode/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "whalelint",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "whalelint",
   "displayName": "WhaleLint",
   "description": "Dockerfile linter writtern in Go.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "TamasGBarna",
   "author": {
     "name": "Tamás G. Barna"


### PR DESCRIPTION
Bugfix: false positive on CPY006 for basic COPY command, without `--from` flag.

Added additional test case for this.
Modified condition to mandate a `from` arg value.