### PR TITLE
bugfix: false positive on run002 when installing from pip requirement…

### DIFF
--- a/linter/ruleset/run002.go
+++ b/linter/ruleset/run002.go
@@ -63,6 +63,10 @@ func ValidateRun002(runCommand *instructions.RunCommand) RuleValidationResult {
 			result.message = "Fedora/RMP"
 		}
 		if Parser.IsPythonPackageInstall(bashCommand) {
+			// case pip install -r [requirement.txt]
+			if Utils.SliceContains(bashCommand.OptionKeyList(), []string{"-r", "--requirement"}) {
+				continue
+			}
 			packageWithoutVersionList = Utils.FilterMapByValue(bashCommand.ArgMap(), filterFunc)
 			result.message = "Python"
 		}

--- a/linter/ruleset/run002_test.go
+++ b/linter/ruleset/run002_test.go
@@ -56,6 +56,13 @@ func TestValidateRun002(t *testing.T) {
 			DocsContext: "FROM ubuntu:20.04\nRUN {{ .CommandStr }}",
 		},
 		{
+			CommandStr:  "pip install --no-cache-dir -r requirements.txt",
+			IsViolation: false,
+			ExampleName: "Install pip packages from requirements file.",
+			DocsContext: "FROM ubuntu:20.04\nRUN {{ .CommandStr }}",
+		},
+
+		{
 			CommandStr:  "date",
 			IsViolation: false,
 			ExampleName: "Unrelated command.",


### PR DESCRIPTION
bugfix: false positive on [`RUN002`](https://github.com/CreMindES/whalelint/blob/main/linter/ruleset/run002.md) when installing from `pip` requirements file.

A simple exception was added to check to `-r`/`--requirement` argument, and a test case of course.

GH-36