### PR TITLE
bugfix: no fallback for rule validation result message.

### DIFF
--- a/linter/ruleset/validationresult.go
+++ b/linter/ruleset/validationresult.go
@@ -35,7 +35,7 @@ func (ruleValidationResult *RuleValidationResult) MarshalJSON() ([]byte, error) 
 	}{
 		Rule:          ruleValidationResult.rule,
 		IsViolated:    ruleValidationResult.isViolated,
-		Message:       ruleValidationResult.message,
+		Message:       ruleValidationResult.Message(),
 		LocationRange: ruleValidationResult.LocationRange,
 	})
 }

--- a/linter/ruleset/validationresult_test.go
+++ b/linter/ruleset/validationresult_test.go
@@ -27,7 +27,7 @@ func TestRuleValidationResult_MarshalJSON(t *testing.T) {
 	mockRule := newMockRule()
 	mockLoc := newMockLocation()
 
-	referenceRuleValidationResult := RuleSet.NewRuleValidationResult(mockRule, false, "", mockLoc)
+	referenceRuleValidationResult := RuleSet.NewRuleValidationResult(mockRule, false, "mockMessage", mockLoc)
 	var duplicateRuleValidationResult RuleSet.RuleValidationResult // nolint:wsl
 
 	// serialize


### PR DESCRIPTION
`RuleValidationResult` marshal was using the member directly, instead of the getter, which has additional fallback logic.