### PR TITLE
bugfix: LSP crash on empty document

### DIFF
--- a/linter/linter.go
+++ b/linter/linter.go
@@ -16,7 +16,11 @@ type Linter struct{}
 // nolint:nestif, funlen, gocognit
 /* Validate each Dockerfile AST entry against rules in ruleset package. */
 func (l *Linter) Run(stageList []instructions.Stage) []RuleSet.RuleValidationResult {
-	var ruleValidationResultArray []RuleSet.RuleValidationResult // nolint:prealloc
+	ruleValidationResultArray := make([]RuleSet.RuleValidationResult, 0)
+
+	if len(stageList) == 0 {
+		return ruleValidationResultArray
+	}
 
 	// Call Dockerfile AST level validators
 	stageListRuleSet := RuleSet.GetRulesForAstElement(stageList)

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -108,7 +108,7 @@ func parseFromText(str string) []instructions.Stage {
 	reader := strings.NewReader(str)
 
 	dockerfile, err := parser.Parse(reader)
-	if err != nil {
+	if err != nil || dockerfile == nil {
 		Log.Error("Cannot parse Dockerfile", err)
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -272,6 +272,10 @@ func GetDockerfileAst(filePathString string) ([]instructions.Stage, []instructio
 //   - there is no more child, in which case it returns an empty stage.
 func ParseDockerfileInstructionsSafely(dockerfile *parser.Result, fileHandle io.ReadSeeker) ([]instructions.Stage,
 	[]instructions.ArgCommand) {
+	if dockerfile == nil {
+		return []instructions.Stage{}, []instructions.ArgCommand{}
+	}
+
 	var (
 		stageList []instructions.Stage
 		metaArgs  []instructions.ArgCommand


### PR DESCRIPTION
Handling empty Dockerfiles gracefully, even publishing an emptied
out Diagnostics in order to make sure that the Problems are gone.

GH-42