### PR TITLE
Bugfix/crash on live edit of run command

### DIFF
--- a/parser/bash.go
+++ b/parser/bash.go
@@ -202,6 +202,10 @@ func ParseBashCommand(bashCommandLex []string) BashCommand {
 	// binary
 	bashCommand.bin, bashCommandLex = bashCommandLex[binaryIndex], bashCommandLex[binaryIndex+1:]
 
+	if len(bashCommandLex) == 0 {
+		return bashCommand
+	}
+
 	// optional subcommand
 	for _, subCommand := range subCommandMap[bashCommand.bin] {
 		if bashCommandLex[0] == subCommand {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -270,6 +270,7 @@ func GetDockerfileAst(filePathString string) ([]instructions.Stage, []instructio
 // - try again until there is
 //   - either a valid AST tree that can be parsed further
 //   - there is no more child, in which case it returns an empty stage.
+// nolint:funlen
 func ParseDockerfileInstructionsSafely(dockerfile *parser.Result, fileHandle io.ReadSeeker) ([]instructions.Stage,
 	[]instructions.ArgCommand) {
 	if dockerfile == nil {


### PR DESCRIPTION
Added additional length check before indexing 0th element in `bashCommandLex` slice.