### PR TITLE
bugfix: apt-get update complains about not being passed -y

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -140,7 +140,7 @@ func (lspCommand *LspCommand) Run() error {
 type VersionCommand struct{}
 
 func (versionCommand *VersionCommand) Run(k *kong.Context) error {
-	version := "v0.0.5"
+	version := "v0.0.6"
 	k.Printf("%s", version)
 
 	return nil

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -67,7 +67,7 @@ func TestVersionCommand_Run(t *testing.T) {
 	err = ctx.Run()
 	assert.NilError(t, err)
 
-	assert.Equal(t, "whalelint: v0.0.5\n", stdBuffer.stdOut.String())
+	assert.Equal(t, "whalelint: v0.0.6\n", stdBuffer.stdOut.String())
 	assert.Equal(t, "", stdBuffer.stdErr.String())
 }
 

--- a/linter/ruleset/locationrange.go
+++ b/linter/ruleset/locationrange.go
@@ -95,6 +95,19 @@ func LocationRangeFromCommand(command instructions.Command) LocationRange {
 	return BKRangeSliceToLocationRange(command.Location())
 }
 
+func LocationRangeToBKRange(locationRange LocationRange) parser.Range {
+	return parser.Range{
+		Start: parser.Position{
+			Line:      locationRange.Start().LineNumber(),
+			Character: locationRange.Start().CharNumber(),
+		},
+		End:   parser.Position{
+			Line:      locationRange.End().LineNumber(),
+			Character: locationRange.End().CharNumber(),
+		},
+	}
+}
+
 func BKRangeSliceToLocationRange(parserRange []parser.Range) LocationRange {
 	if parserRange == nil {
 		return LocationRange{

--- a/linter/ruleset/run009.go
+++ b/linter/ruleset/run009.go
@@ -7,7 +7,7 @@ import (
 	Utils "github.com/cremindes/whalelint/utils"
 )
 
-var _ = NewRule("RUN009", "Pass -y|--yes|--assume-yes flag to apt-get in order to be headless.", "",
+var _ = NewRule("RUN009", "Pass assume yes flag to package manager in order to be headless.", "",
 	ValWarning, ValidateRun009)
 
 func ValidateRun009(runCommand *instructions.RunCommand) RuleValidationResult {
@@ -16,18 +16,29 @@ func ValidateRun009(runCommand *instructions.RunCommand) RuleValidationResult {
 		LocationRange: LocationRangeFromCommand(runCommand),
 	}
 
-	packageManagerConfirmOptionMap := map[string][]string{
-		"apt":     {"-y", "--yes", "--assume-yes"},
-		"apt-get": {"-y", "--yes", "--assume-yes"},
-		"dnf":     {"-y", "--assumeyes"},
-		"yum":     {"-y", "--assumeyes"},
-		"zypper":  {"-y", "--no-confirm", "-n", "--non-interactive"},
+	packageManagerConfirmOptionMap := map[string]struct {
+		subcommandSlice []string
+		assumeYesSlice  []string
+	}{
+		"apt":     {[]string{"install", "remove", "purge"}, []string{"-y", "--yes", "--assume-yes"}},
+		"apt-get": {[]string{"install", "remove", "purge"}, []string{"-y", "--yes", "--assume-yes"}},
+		"dnf":     {[]string{"install", "remove", "downgrade"}, []string{"-y", "--assumeyes"}},
+		"yum":     {[]string{"install", "remove", "downgrade"}, []string{"-y", "--assumeyes"}},
+		"zypper": {
+			[]string{"install", "in", "remove", "rm"},
+			[]string{"-y", "--no-confirm", "-n", "--non-interactive"},
+		},
 	}
 
 	bashCommandList := Parser.ParseBashCommandList(runCommand.CmdLine)
 	for _, bashCommand := range bashCommandList {
-		if assumeYesSlice, ok := packageManagerConfirmOptionMap[bashCommand.Bin()]; ok {
-			if !Utils.SliceContains(bashCommand.OptionKeyList(), assumeYesSlice) {
+		if len(bashCommand.SubCommand()) == 0 {
+			continue
+		}
+
+		if pmMap, ok := packageManagerConfirmOptionMap[bashCommand.Bin()]; ok {
+			if Utils.SliceContains(pmMap.subcommandSlice, bashCommand.SubCommand()) &&
+				!Utils.SliceContains(bashCommand.OptionKeyList(), pmMap.assumeYesSlice) {
 				result.SetViolated()
 				result.LocationRange = ParseLocationFromRawParser(bashCommand.Bin(), runCommand.Location())
 			}

--- a/linter/ruleset/run009_test.go
+++ b/linter/ruleset/run009_test.go
@@ -21,8 +21,10 @@ func TestValidateRun009(t *testing.T) {
 		{commandStr: "apt-get --yes install vim", isViolation: false},
 		{commandStr: "apt-get --assume-yes install vim", isViolation: false},
 		{commandStr: "apt-get install vim", isViolation:  true},
-		{commandStr: "DEBIAN_FRONTEND=noninteractive apt-get update", isViolation: true},
-		{commandStr: "DEBIAN_FRONTEND=noninteractive apt     update", isViolation: true},
+		{commandStr: "DEBIAN_FRONTEND=noninteractive apt-get update", isViolation: false},
+		{commandStr: "DEBIAN_FRONTEND=noninteractive apt     update", isViolation: false},
+		{commandStr: "apt-get update && apt-get install vim", isViolation: true},
+		{commandStr: "apt-get update && apt-get install --yes vim", isViolation: false},
 		{commandStr: "date", isViolation: false},
 		{commandStr: "date && date", isViolation: false},
 	}

--- a/parser/rawdf.go
+++ b/parser/rawdf.go
@@ -47,24 +47,32 @@ func (r *RawDockerfileParser) ParseDockerfile(filePath string) error {
 
 func (r *RawDockerfileParser) StringLocation(str string, window []parser.Range) [4]int {
 	windowStart, windowEnd := 0, 0
+	windowStartChar := 0
 
 	switch len(window) {
 	case 0:
 		windowStart, windowEnd = 0, len(r.rawLines)-1
 	case 1:
 		windowStart, windowEnd = window[0].Start.Line-1, window[0].Start.Line
+		windowStartChar = window[0].Start.Character
 	default:
 		windowStart, windowEnd = window[0].Start.Line-1, window[len(window)-1].End.Line
+		windowStartChar = window[0].Start.Character
 	}
 
 	searchWindow := r.rawLines[windowStart:windowEnd]
 
 	for i, line := range searchWindow {
+		// tmp workaround till bash parser can work together with raw parser
+		if i == 0 {
+			line = line[windowStartChar:]
+		}
+
 		if strings.Contains(line, str) {
 			startLine := i
-			startChar := strings.Index(line, str)
+			startChar := strings.Index(line, str) + windowStartChar
 			endLine := i
-			endChar := strings.Index(line, str) + len(str)
+			endChar := strings.Index(line, str) + len(str) + windowStartChar
 
 			return [4]int{
 				windowStart + startLine + 1,
@@ -72,6 +80,10 @@ func (r *RawDockerfileParser) StringLocation(str string, window []parser.Range) 
 				windowStart + endLine + 1,
 				endChar,
 			}
+		}
+
+		if i == 0 {
+			windowStartChar = 0
 		}
 	}
 

--- a/plugins/vscode/CHANGELOG.md
+++ b/plugins/vscode/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v0.0.6 - 11th March 2021
+
+- Bug fixes:
+  - RUN009 wrong target - apt-get update instead of apt-get install for assume yes flag check |
+    [GitHub Issue #53](https://github.com/CreMindES/whalelint/issues/53)
+  - Wrong location on RUN009 for bash commands with repeating patterns |
+    [GitHub Issue #53](https://github.com/CreMindES/whalelint/issues/53)
+
 ## v0.0.5 - 8th March 2021
 
 - Bug fix:

--- a/plugins/vscode/package-lock.json
+++ b/plugins/vscode/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "whalelint",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "whalelint",
   "displayName": "WhaleLint",
   "description": "Dockerfile linter written in Go.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publisher": "TamasGBarna",
   "author": {
     "name": "Tamás G. Barna"


### PR DESCRIPTION
Fixing mismatch in rule `RUN009`. This rule checks assume yes flag which were the same for all package managers. Now it has been extended to package manager map, which couples package manager and it's (supported) subcommands that need assume yes flag when used.

GH-53