### PR TITLE
bugfix: false positive for STS001 when from is scratch.

### DIFF
--- a/linter/ruleset/sts001.go
+++ b/linter/ruleset/sts001.go
@@ -12,6 +12,10 @@ var _ = NewRule("STS001", "Stage name should have an explicit tag..", "", ValWar
 func ValidateSts001(stage instructions.Stage) RuleValidationResult {
 	result := RuleValidationResult{isViolated: false, LocationRange: BKRangeSliceToLocationRange(stage.Location)}
 
+	if stage.BaseName == "scratch" { // special explicitly empty image
+		return result
+	}
+
 	image, tag := utils.SplitKeyValue(stage.BaseName, ':')
 	result.SetViolated(tag == "")
 


### PR DESCRIPTION
Special empty base image `scratch` has been added as an exception to `STS001`.